### PR TITLE
feat(e-commerce): complete based logistic shipping reports

### DIFF
--- a/apps/e-commerce/src/report/based-logistic/admin-courier/admin-courier.controller.ts
+++ b/apps/e-commerce/src/report/based-logistic/admin-courier/admin-courier.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { CheckPermission } from '@rahino/permission-checker/decorator';
+import { PermissionGuard } from '@rahino/permission-checker/guard';
+import { JsonResponseTransformInterceptor } from '@rahino/response/interceptor';
+import { JwtGuard } from '@rahino/auth';
+import { BasedAdminCourierService } from './admin-courier.service';
+import { GetAdminCourierDto } from '../../admin-courier/dto';
+
+@ApiTags('Report-AdminCouriers-BasedLogistic')
+@UseGuards(JwtGuard, PermissionGuard)
+@UseInterceptors(JsonResponseTransformInterceptor)
+@ApiBearerAuth()
+@Controller({ path: '/api/ecommerce/report/basedLogistic/adminCouriers', version: ['1'] })
+export class BasedAdminCourierController {
+  constructor(private readonly service: BasedAdminCourierService) {}
+
+  @ApiOperation({ description: 'show all couriers report admin (based-logistic)' })
+  @CheckPermission({ permissionSymbol: 'ecommerce.report.admincouriers.getall' })
+  @Get('/')
+  @ApiQuery({ name: 'filter', type: GetAdminCourierDto, style: 'deepObject', explode: true })
+  @HttpCode(HttpStatus.OK)
+  async findAll(@Query() filter: GetAdminCourierDto) {
+    return await this.service.findAll(filter);
+  }
+
+  @ApiOperation({ description: 'show total admin courier report (based-logistic)' })
+  @CheckPermission({ permissionSymbol: 'ecommerce.report.admincouriers.getall' })
+  @Get('/total')
+  @ApiQuery({ name: 'filter', type: GetAdminCourierDto, style: 'deepObject', explode: true })
+  @HttpCode(HttpStatus.OK)
+  async total(@Query() filter: GetAdminCourierDto) {
+    return await this.service.total(filter);
+  }
+}

--- a/apps/e-commerce/src/report/based-logistic/admin-courier/admin-courier.module.ts
+++ b/apps/e-commerce/src/report/based-logistic/admin-courier/admin-courier.module.ts
@@ -1,4 +1,22 @@
 import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { Permission, PersianDate } from '@rahino/database';
+import { ECLogisticOrderGrouped, User } from '@rahino/localdatabase/models';
+import { BasedAdminCourierController } from './admin-courier.controller';
+import { BasedAdminCourierService } from './admin-courier.service';
+import { LogisticOrderQueryBuilderModule } from '../order-query-builder/logistic-order-query-builder.module';
 
-@Module({})
+@Module({
+  imports: [
+    LogisticOrderQueryBuilderModule,
+    SequelizeModule.forFeature([
+      PersianDate,
+      ECLogisticOrderGrouped,
+      User,
+      Permission,
+    ]),
+  ],
+  controllers: [BasedAdminCourierController],
+  providers: [BasedAdminCourierService],
+})
 export class BasedAdminCourierReportModule {}

--- a/apps/e-commerce/src/report/based-logistic/admin-courier/admin-courier.service.ts
+++ b/apps/e-commerce/src/report/based-logistic/admin-courier/admin-courier.service.ts
@@ -1,0 +1,173 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { PersianDate } from '@rahino/database';
+import { ECLogisticOrderGrouped } from '@rahino/localdatabase/models';
+import { QueryOptionsBuilder } from '@rahino/query-filter/sequelize-query-builder';
+import { I18nContext, I18nService } from 'nestjs-i18n';
+import { I18nTranslations } from 'apps/main/src/generated/i18n.generated';
+import { LogisticOrderQueryBuilderService } from '../order-query-builder/logistic-order-query-builder.service';
+import { GetAdminCourierDto } from '../../admin-courier/dto';
+import { OrderShipmentwayEnum, OrderStatusEnum } from '@rahino/ecommerce/shared/enum';
+import { Sequelize } from 'sequelize';
+
+@Injectable()
+export class BasedAdminCourierService {
+  constructor(
+    @InjectModel(ECLogisticOrderGrouped)
+    private readonly groupedRepository: typeof ECLogisticOrderGrouped,
+    @InjectModel(PersianDate)
+    private readonly persianDateRepository: typeof PersianDate,
+    private readonly i18n: I18nService<I18nTranslations>,
+    private readonly orderQueryBuilder: LogisticOrderQueryBuilderService,
+  ) {}
+
+  async findAll(filter: GetAdminCourierDto) {
+    await this.validateDates(filter.beginDate, filter.endDate);
+
+    let qb = this.orderQueryBuilder
+      .init(false)
+      .nonDeletedGroup()
+      .nonDeletedOrder()
+      .addNegativeOrderStatus(OrderStatusEnum.WaitingForPayment)
+      .addShipmentWay(OrderShipmentwayEnum.delivery)
+      .addBeginDate(filter.beginDate)
+      .addEndDate(filter.endDate);
+
+    if (filter.courierId) {
+      qb = qb.addCourier(filter.courierId);
+    }
+    if (filter.orderId) {
+      qb = qb.addOrderId(filter.orderId);
+    }
+
+    const count = await this.groupedRepository.count(qb.build());
+
+    qb = qb
+      .attributes([
+        'id',
+        'orderStatusId',
+        'courierUserId',
+        'deliveryDate',
+        'sendToCustomerDate',
+        'postReceipt',
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.col('ECLogisticOrderGrouped.realShipmentPrice'),
+            0,
+          ),
+          'realShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.col('ECLogisticOrderGrouped.shipmentPrice'),
+            0,
+          ),
+          'totalShipmentPrice',
+        ],
+        [
+          Sequelize.literal(
+            'isnull(ECLogisticOrderGrouped.shipmentPrice, 0) - isnull(ECLogisticOrderGrouped.realShipmentPrice, 0)',
+          ),
+          'profitAmount',
+        ],
+      ])
+      .includeCourierUser()
+      .includeOrderStatus()
+      .offset(filter.offset)
+      .limit(filter.limit);
+
+    const result = await this.groupedRepository.findAll(qb.build());
+    return { result, total: count };
+  }
+
+  async total(filter: GetAdminCourierDto) {
+    await this.validateDates(filter.beginDate, filter.endDate);
+
+    let qb = this.orderQueryBuilder
+      .init(true)
+      .nonDeletedGroup()
+      .nonDeletedOrder()
+      .addNegativeOrderStatus(OrderStatusEnum.WaitingForPayment)
+      .addShipmentWay(OrderShipmentwayEnum.delivery)
+      .addBeginDate(filter.beginDate)
+      .addEndDate(filter.endDate);
+
+    if (filter.courierId) {
+      qb = qb.addCourier(filter.courierId);
+    }
+    if (filter.orderId) {
+      qb = qb.addOrderId(filter.orderId);
+    }
+
+    qb = qb
+      .attributes([
+        [Sequelize.fn('count', Sequelize.col('ECLogisticOrderGrouped.id')), 'cntOrder'],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.fn(
+              'sum',
+              Sequelize.col('ECLogisticOrderGrouped.realShipmentPrice'),
+            ),
+            0,
+          ),
+          'realShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.fn('sum', Sequelize.col('ECLogisticOrderGrouped.shipmentPrice')),
+            0,
+          ),
+          'totalShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.literal(
+              'SUM(isnull(ECLogisticOrderGrouped.shipmentPrice, 0) - isnull(ECLogisticOrderGrouped.realShipmentPrice, 0))',
+            ),
+            0,
+          ),
+          'profitAmount',
+        ],
+      ])
+      .rawQuery(true);
+
+    const findOptions = qb.build();
+    findOptions.order = null as any;
+    findOptions.offset = null as any;
+    findOptions.limit = null as any;
+
+    const result = await this.groupedRepository.findOne(findOptions);
+    return { result };
+  }
+
+  private async validateDates(beginDate: string, endDate: string) {
+    const isValidBeginDate = await this.isValidDate(beginDate);
+    if (!isValidBeginDate) {
+      throw new BadRequestException(
+        this.i18n.t('ecommerce.date_is_invalid', {
+          lang: I18nContext.current().lang,
+        }),
+      );
+    }
+    const isValidEndDate = await this.isValidDate(endDate);
+    if (!isValidEndDate) {
+      throw new BadRequestException(
+        this.i18n.t('ecommerce.date_is_invalid', {
+          lang: I18nContext.current().lang,
+        }),
+      );
+    }
+  }
+
+  private async isValidDate(date: string) {
+    const findDate = await this.persianDateRepository.findOne(
+      new QueryOptionsBuilder().filter({ GregorianDate: date }).build(),
+    );
+    return !!findDate;
+  }
+}

--- a/apps/e-commerce/src/report/based-logistic/admin-post/admin-post.controller.ts
+++ b/apps/e-commerce/src/report/based-logistic/admin-post/admin-post.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { CheckPermission } from '@rahino/permission-checker/decorator';
+import { PermissionGuard } from '@rahino/permission-checker/guard';
+import { JsonResponseTransformInterceptor } from '@rahino/response/interceptor';
+import { JwtGuard } from '@rahino/auth';
+import { BasedAdminPostService } from './admin-post.service';
+import { GetAdminPostDto } from '../../admin-post/dto';
+
+@ApiTags('Report-AdminPosts-BasedLogistic')
+@UseGuards(JwtGuard, PermissionGuard)
+@UseInterceptors(JsonResponseTransformInterceptor)
+@ApiBearerAuth()
+@Controller({ path: '/api/ecommerce/report/basedLogistic/adminPosts', version: ['1'] })
+export class BasedAdminPostController {
+  constructor(private readonly service: BasedAdminPostService) {}
+
+  @ApiOperation({ description: 'show all posts report admin (based-logistic)' })
+  @CheckPermission({ permissionSymbol: 'ecommerce.report.adminposts.getall' })
+  @Get('/')
+  @ApiQuery({ name: 'filter', type: GetAdminPostDto, style: 'deepObject', explode: true })
+  @HttpCode(HttpStatus.OK)
+  async findAll(@Query() filter: GetAdminPostDto) {
+    return await this.service.findAll(filter);
+  }
+
+  @ApiOperation({ description: 'show total admin post report (based-logistic)' })
+  @CheckPermission({ permissionSymbol: 'ecommerce.report.adminposts.getall' })
+  @Get('/total')
+  @ApiQuery({ name: 'filter', type: GetAdminPostDto, style: 'deepObject', explode: true })
+  @HttpCode(HttpStatus.OK)
+  async total(@Query() filter: GetAdminPostDto) {
+    return await this.service.total(filter);
+  }
+}

--- a/apps/e-commerce/src/report/based-logistic/admin-post/admin-post.module.ts
+++ b/apps/e-commerce/src/report/based-logistic/admin-post/admin-post.module.ts
@@ -1,4 +1,17 @@
 import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { Permission, PersianDate } from '@rahino/database';
+import { ECLogisticOrderGrouped } from '@rahino/localdatabase/models';
+import { BasedAdminPostController } from './admin-post.controller';
+import { BasedAdminPostService } from './admin-post.service';
+import { LogisticOrderQueryBuilderModule } from '../order-query-builder/logistic-order-query-builder.module';
 
-@Module({})
+@Module({
+  imports: [
+    LogisticOrderQueryBuilderModule,
+    SequelizeModule.forFeature([PersianDate, ECLogisticOrderGrouped, Permission]),
+  ],
+  controllers: [BasedAdminPostController],
+  providers: [BasedAdminPostService],
+})
 export class BasedAdminPostReportModule {}

--- a/apps/e-commerce/src/report/based-logistic/admin-post/admin-post.service.ts
+++ b/apps/e-commerce/src/report/based-logistic/admin-post/admin-post.service.ts
@@ -1,0 +1,166 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { PersianDate } from '@rahino/database';
+import { ECLogisticOrderGrouped } from '@rahino/localdatabase/models';
+import { QueryOptionsBuilder } from '@rahino/query-filter/sequelize-query-builder';
+import { I18nContext, I18nService } from 'nestjs-i18n';
+import { I18nTranslations } from 'apps/main/src/generated/i18n.generated';
+import { LogisticOrderQueryBuilderService } from '../order-query-builder/logistic-order-query-builder.service';
+import { GetAdminPostDto } from '../../admin-post/dto';
+import { OrderShipmentwayEnum, OrderStatusEnum } from '@rahino/ecommerce/shared/enum';
+import { Sequelize } from 'sequelize';
+
+@Injectable()
+export class BasedAdminPostService {
+  constructor(
+    @InjectModel(ECLogisticOrderGrouped)
+    private readonly groupedRepository: typeof ECLogisticOrderGrouped,
+    @InjectModel(PersianDate)
+    private readonly persianDateRepository: typeof PersianDate,
+    private readonly i18n: I18nService<I18nTranslations>,
+    private readonly orderQueryBuilder: LogisticOrderQueryBuilderService,
+  ) {}
+
+  async findAll(filter: GetAdminPostDto) {
+    await this.validateDates(filter.beginDate, filter.endDate);
+
+    let qb = this.orderQueryBuilder
+      .init(false)
+      .nonDeletedGroup()
+      .nonDeletedOrder()
+      .addNegativeOrderStatus(OrderStatusEnum.WaitingForPayment)
+      .addShipmentWay(OrderShipmentwayEnum.post)
+      .addBeginDate(filter.beginDate)
+      .addEndDate(filter.endDate);
+
+    if (filter.orderId) {
+      qb = qb.addOrderId(filter.orderId);
+    }
+
+    const count = await this.groupedRepository.count(qb.build());
+
+    qb = qb
+      .attributes([
+        'id',
+        'orderStatusId',
+        'courierUserId',
+        'deliveryDate',
+        'sendToCustomerDate',
+        'postReceipt',
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.col('ECLogisticOrderGrouped.realShipmentPrice'),
+            0,
+          ),
+          'realShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.col('ECLogisticOrderGrouped.shipmentPrice'),
+            0,
+          ),
+          'totalShipmentPrice',
+        ],
+        [
+          Sequelize.literal(
+            'isnull(ECLogisticOrderGrouped.shipmentPrice, 0) - isnull(ECLogisticOrderGrouped.realShipmentPrice, 0)',
+          ),
+          'profitAmount',
+        ],
+      ])
+      .includeOrderStatus()
+      .offset(filter.offset)
+      .limit(filter.limit);
+
+    const result = await this.groupedRepository.findAll(qb.build());
+    return { result, total: count };
+  }
+
+  async total(filter: GetAdminPostDto) {
+    await this.validateDates(filter.beginDate, filter.endDate);
+
+    let qb = this.orderQueryBuilder
+      .init(true)
+      .nonDeletedGroup()
+      .nonDeletedOrder()
+      .addNegativeOrderStatus(OrderStatusEnum.WaitingForPayment)
+      .addShipmentWay(OrderShipmentwayEnum.post)
+      .addBeginDate(filter.beginDate)
+      .addEndDate(filter.endDate);
+
+    if (filter.orderId) {
+      qb = qb.addOrderId(filter.orderId);
+    }
+
+    qb = qb
+      .attributes([
+        [Sequelize.fn('count', Sequelize.col('ECLogisticOrderGrouped.id')), 'cntOrder'],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.fn(
+              'sum',
+              Sequelize.col('ECLogisticOrderGrouped.realShipmentPrice'),
+            ),
+            0,
+          ),
+          'realShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.fn('sum', Sequelize.col('ECLogisticOrderGrouped.shipmentPrice')),
+            0,
+          ),
+          'totalShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.literal(
+              'SUM(isnull(ECLogisticOrderGrouped.shipmentPrice, 0) - isnull(ECLogisticOrderGrouped.realShipmentPrice, 0))',
+            ),
+            0,
+          ),
+          'profitAmount',
+        ],
+      ])
+      .rawQuery(true);
+
+    const findOptions = qb.build();
+    findOptions.order = null as any;
+    findOptions.offset = null as any;
+    findOptions.limit = null as any;
+
+    const result = await this.groupedRepository.findOne(findOptions);
+    return { result };
+  }
+
+  private async validateDates(beginDate: string, endDate: string) {
+    const isValidBeginDate = await this.isValidDate(beginDate);
+    if (!isValidBeginDate) {
+      throw new BadRequestException(
+        this.i18n.t('ecommerce.date_is_invalid', {
+          lang: I18nContext.current().lang,
+        }),
+      );
+    }
+    const isValidEndDate = await this.isValidDate(endDate);
+    if (!isValidEndDate) {
+      throw new BadRequestException(
+        this.i18n.t('ecommerce.date_is_invalid', {
+          lang: I18nContext.current().lang,
+        }),
+      );
+    }
+  }
+
+  private async isValidDate(date: string) {
+    const findDate = await this.persianDateRepository.findOne(
+      new QueryOptionsBuilder().filter({ GregorianDate: date }).build(),
+    );
+    return !!findDate;
+  }
+}

--- a/apps/e-commerce/src/report/based-logistic/courier/courier-report.controller.ts
+++ b/apps/e-commerce/src/report/based-logistic/courier/courier-report.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  Req,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JsonResponseTransformInterceptor } from '@rahino/response/interceptor';
+import { JwtGuard } from '@rahino/auth';
+import { Request } from 'express';
+import { BasedCourierReportService } from './courier-report.service';
+import { GetCourierReportDto } from '../../courier/dto';
+
+@ApiTags('Report-Couriers-BasedLogistic')
+@UseGuards(JwtGuard)
+@UseInterceptors(JsonResponseTransformInterceptor)
+@ApiBearerAuth()
+@Controller({ path: '/api/ecommerce/report/basedLogistic/couriers', version: ['1'] })
+export class BasedCourierReportController {
+  constructor(private readonly service: BasedCourierReportService) {}
+
+  @ApiOperation({ description: 'show all couriers report (based-logistic)' })
+  @Get('/')
+  @ApiQuery({ name: 'filter', type: GetCourierReportDto, style: 'deepObject', explode: true })
+  @HttpCode(HttpStatus.OK)
+  async findAll(@Req() req: Request, @Query() filter: GetCourierReportDto) {
+    return await this.service.findAll(req.user as any, filter);
+  }
+
+  @ApiOperation({ description: 'show total courier report (based-logistic)' })
+  @Get('/total')
+  @ApiQuery({ name: 'filter', type: GetCourierReportDto, style: 'deepObject', explode: true })
+  @HttpCode(HttpStatus.OK)
+  async total(@Req() req: Request, @Query() filter: GetCourierReportDto) {
+    return await this.service.total(req.user as any, filter);
+  }
+}

--- a/apps/e-commerce/src/report/based-logistic/courier/courier-report.module.ts
+++ b/apps/e-commerce/src/report/based-logistic/courier/courier-report.module.ts
@@ -1,4 +1,17 @@
 import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { PersianDate } from '@rahino/database';
+import { ECLogisticOrderGrouped, User } from '@rahino/localdatabase/models';
+import { BasedCourierReportController } from './courier-report.controller';
+import { BasedCourierReportService } from './courier-report.service';
+import { LogisticOrderQueryBuilderModule } from '../order-query-builder/logistic-order-query-builder.module';
 
-@Module({})
+@Module({
+  imports: [
+    LogisticOrderQueryBuilderModule,
+    SequelizeModule.forFeature([PersianDate, ECLogisticOrderGrouped, User]),
+  ],
+  controllers: [BasedCourierReportController],
+  providers: [BasedCourierReportService],
+})
 export class BasedCourierReportModule {}

--- a/apps/e-commerce/src/report/based-logistic/courier/courier-report.service.ts
+++ b/apps/e-commerce/src/report/based-logistic/courier/courier-report.service.ts
@@ -1,0 +1,170 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { PersianDate } from '@rahino/database';
+import { ECLogisticOrderGrouped } from '@rahino/localdatabase/models';
+import { QueryOptionsBuilder } from '@rahino/query-filter/sequelize-query-builder';
+import { I18nContext, I18nService } from 'nestjs-i18n';
+import { I18nTranslations } from 'apps/main/src/generated/i18n.generated';
+import { LogisticOrderQueryBuilderService } from '../order-query-builder/logistic-order-query-builder.service';
+import { GetCourierReportDto } from '../../courier/dto';
+import { OrderShipmentwayEnum, OrderStatusEnum } from '@rahino/ecommerce/shared/enum';
+import { Sequelize } from 'sequelize';
+import { User } from '@rahino/database';
+
+@Injectable()
+export class BasedCourierReportService {
+  constructor(
+    @InjectModel(ECLogisticOrderGrouped)
+    private readonly groupedRepository: typeof ECLogisticOrderGrouped,
+    @InjectModel(PersianDate)
+    private readonly persianDateRepository: typeof PersianDate,
+    private readonly i18n: I18nService<I18nTranslations>,
+    private readonly orderQueryBuilder: LogisticOrderQueryBuilderService,
+  ) {}
+
+  async findAll(user: User, filter: GetCourierReportDto) {
+    await this.validateDates(filter.beginDate, filter.endDate);
+
+    let qb = this.orderQueryBuilder
+      .init(false)
+      .nonDeletedGroup()
+      .nonDeletedOrder()
+      .addNegativeOrderStatus(OrderStatusEnum.WaitingForPayment)
+      .addShipmentWay(OrderShipmentwayEnum.delivery)
+      .addCourier(user.id)
+      .addBeginDate(filter.beginDate)
+      .addEndDate(filter.endDate);
+
+    if (filter.orderId) {
+      qb = qb.addOrderId(filter.orderId);
+    }
+
+    const count = await this.groupedRepository.count(qb.build());
+
+    qb = qb
+      .attributes([
+        'id',
+        'orderStatusId',
+        'courierUserId',
+        'deliveryDate',
+        'sendToCustomerDate',
+        'postReceipt',
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.col('ECLogisticOrderGrouped.realShipmentPrice'),
+            0,
+          ),
+          'realShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.col('ECLogisticOrderGrouped.shipmentPrice'),
+            0,
+          ),
+          'totalShipmentPrice',
+        ],
+        [
+          Sequelize.literal(
+            'isnull(ECLogisticOrderGrouped.shipmentPrice, 0) - isnull(ECLogisticOrderGrouped.realShipmentPrice, 0)',
+          ),
+          'profitAmount',
+        ],
+      ])
+      .includeCourierUser()
+      .includeOrderStatus()
+      .offset(filter.offset)
+      .limit(filter.limit);
+
+    const result = await this.groupedRepository.findAll(qb.build());
+    return { result, total: count };
+  }
+
+  async total(user: User, filter: GetCourierReportDto) {
+    await this.validateDates(filter.beginDate, filter.endDate);
+
+    let qb = this.orderQueryBuilder
+      .init(true)
+      .nonDeletedGroup()
+      .nonDeletedOrder()
+      .addNegativeOrderStatus(OrderStatusEnum.WaitingForPayment)
+      .addShipmentWay(OrderShipmentwayEnum.delivery)
+      .addCourier(user.id)
+      .addBeginDate(filter.beginDate)
+      .addEndDate(filter.endDate);
+
+    if (filter.orderId) {
+      qb = qb.addOrderId(filter.orderId);
+    }
+
+    qb = qb
+      .attributes([
+        [Sequelize.fn('count', Sequelize.col('ECLogisticOrderGrouped.id')), 'cntOrder'],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.fn(
+              'sum',
+              Sequelize.col('ECLogisticOrderGrouped.realShipmentPrice'),
+            ),
+            0,
+          ),
+          'realShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.fn('sum', Sequelize.col('ECLogisticOrderGrouped.shipmentPrice')),
+            0,
+          ),
+          'totalShipmentPrice',
+        ],
+        [
+          Sequelize.fn(
+            'isnull',
+            Sequelize.literal(
+              'SUM(isnull(ECLogisticOrderGrouped.shipmentPrice, 0) - isnull(ECLogisticOrderGrouped.realShipmentPrice, 0))',
+            ),
+            0,
+          ),
+          'profitAmount',
+        ],
+      ])
+      .rawQuery(true);
+
+    const findOptions = qb.build();
+    findOptions.order = null as any;
+    findOptions.offset = null as any;
+    findOptions.limit = null as any;
+
+    const result = await this.groupedRepository.findOne(findOptions);
+    return { result };
+  }
+
+  private async validateDates(beginDate: string, endDate: string) {
+    const isValidBeginDate = await this.isValidDate(beginDate);
+    if (!isValidBeginDate) {
+      throw new BadRequestException(
+        this.i18n.t('ecommerce.date_is_invalid', {
+          lang: I18nContext.current().lang,
+        }),
+      );
+    }
+    const isValidEndDate = await this.isValidDate(endDate);
+    if (!isValidEndDate) {
+      throw new BadRequestException(
+        this.i18n.t('ecommerce.date_is_invalid', {
+          lang: I18nContext.current().lang,
+        }),
+      );
+    }
+  }
+
+  private async isValidDate(date: string) {
+    const findDate = await this.persianDateRepository.findOne(
+      new QueryOptionsBuilder().filter({ GregorianDate: date }).build(),
+    );
+    return !!findDate;
+  }
+}

--- a/apps/e-commerce/src/report/based-logistic/order-query-builder/logistic-order-query-builder.module.ts
+++ b/apps/e-commerce/src/report/based-logistic/order-query-builder/logistic-order-query-builder.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { LogisticOrderQueryBuilderService } from './logistic-order-query-builder.service';
+
+@Module({
+  providers: [LogisticOrderQueryBuilderService],
+  exports: [LogisticOrderQueryBuilderService],
+})
+export class LogisticOrderQueryBuilderModule {}

--- a/apps/e-commerce/src/report/based-logistic/order-query-builder/logistic-order-query-builder.service.ts
+++ b/apps/e-commerce/src/report/based-logistic/order-query-builder/logistic-order-query-builder.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { User } from '@rahino/database';
+import {
+  ECLogisticOrder,
+  ECLogisticOrderGrouped,
+  ECOrderStatus,
+} from '@rahino/localdatabase/models';
+import { OrderShipmentwayEnum, OrderStatusEnum } from '@rahino/ecommerce/shared/enum';
+import { QueryOptionsBuilder } from '@rahino/query-filter/sequelize-query-builder';
+import { FindAttributeOptions, Op, Order, Sequelize } from 'sequelize';
+
+@Injectable({ scope: Scope.REQUEST })
+export class LogisticOrderQueryBuilderService {
+  private builder: QueryOptionsBuilder;
+  private groupByQuery = false;
+
+  constructor() {
+    this.builder = new QueryOptionsBuilder();
+    this.builder.include([]);
+  }
+
+  init(groupByQuery: boolean) {
+    this.groupByQuery = groupByQuery;
+    this.builder = new QueryOptionsBuilder();
+    this.builder.include([]);
+    this.builder = this.builder.thenInclude({
+      attributes: [],
+      model: ECLogisticOrder,
+      as: 'logisticOrder',
+      required: true,
+    });
+    return this;
+  }
+
+  nonDeletedGroup() {
+    this.builder = this.builder.filter(
+      Sequelize.where(
+        Sequelize.fn('isnull', Sequelize.col('ECLogisticOrderGrouped.isDeleted'), 0),
+        { [Op.eq]: 0 },
+      ),
+    );
+    return this;
+  }
+
+  nonDeletedOrder() {
+    this.builder = this.builder.filter(
+      Sequelize.where(
+        Sequelize.fn('isnull', Sequelize.col('logisticOrder.isDeleted'), 0),
+        { [Op.eq]: 0 },
+      ),
+    );
+    return this;
+  }
+
+  addBeginDate(beginDate: string) {
+    this.builder = this.builder.filter({
+      '$logisticOrder.gregorianAtPersian$': { [Op.gte]: beginDate },
+    });
+    return this;
+  }
+
+  addEndDate(endDate: string) {
+    this.builder = this.builder.filter({
+      '$logisticOrder.gregorianAtPersian$': {
+        [Op.lt]: Sequelize.fn(
+          'dateadd',
+          Sequelize.literal('day'),
+          Sequelize.literal('1'),
+          endDate,
+        ),
+      },
+    });
+    return this;
+  }
+
+  addShipmentWay(shipmentType: OrderShipmentwayEnum) {
+    this.builder = this.builder.filter({ orderShipmentWayId: shipmentType });
+    return this;
+  }
+
+  addNegativeOrderStatus(orderStatus: OrderStatusEnum) {
+    this.builder = this.builder
+      .filter({
+        orderStatusId: {
+          [Op.ne]: orderStatus,
+        },
+      })
+      .filter({
+        '$logisticOrder.orderStatusId$': {
+          [Op.ne]: orderStatus,
+        },
+      });
+    return this;
+  }
+
+  addCourier(userId: bigint) {
+    this.builder = this.builder.filter({ courierUserId: userId });
+    return this;
+  }
+
+  addOrderId(orderId: bigint) {
+    this.builder = this.builder.filter({ logisticOrderId: orderId });
+    return this;
+  }
+
+  includeCourierUser() {
+    this.builder = this.builder.thenInclude({
+      attributes: this.groupByQuery
+        ? []
+        : ['id', 'firstname', 'lastname', 'username', 'phoneNumber'],
+      model: User,
+      as: 'courierUser',
+      required: false,
+    });
+    return this;
+  }
+
+  includeOrderStatus() {
+    this.builder = this.builder.thenInclude({
+      attributes: this.groupByQuery ? [] : ['id', 'name'],
+      model: ECOrderStatus,
+      as: 'orderStatus',
+      required: false,
+    });
+    return this;
+  }
+
+  attributes(attributes: FindAttributeOptions) {
+    this.builder = this.builder.attributes(attributes);
+    return this;
+  }
+
+  limit(limit: number) {
+    this.builder = this.builder.limit(limit);
+    return this;
+  }
+
+  offset(offset: number) {
+    this.builder = this.builder.offset(offset);
+    return this;
+  }
+
+  order(orderArg: Order) {
+    this.builder = this.builder.order(orderArg);
+    return this;
+  }
+
+  rawQuery(flag: boolean) {
+    this.builder = this.builder.raw(flag);
+    return this;
+  }
+
+  build() {
+    return this.builder.build();
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable logistic order query builder for grouped shipment lookups
- implement based-logistic admin post, admin courier, and courier report services and controllers on the new models
- wire up the based-logistic report modules to provide the updated services

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904f1eaa0bc832f8ed0495cda260283